### PR TITLE
Earth 134

### DIFF
--- a/modules/ui_patterns_variants/ui_patterns_variants.module
+++ b/modules/ui_patterns_variants/ui_patterns_variants.module
@@ -449,6 +449,7 @@ function _ui_patterns_variants_get_variants($pattern_id) {
  *   Imploded field values.
  */
 function _ui_patterns_variants_entity_variant_value($entity, $variant_field) {
+
   $entity_fields = $entity->getFieldDefinitions();
 
   if (!$entity_fields || !isset($entity_fields[$variant_field])) {
@@ -456,10 +457,24 @@ function _ui_patterns_variants_entity_variant_value($entity, $variant_field) {
   }
 
   $field_values = $entity->get($variant_field)->getValue();
-  foreach ($field_values as &$value) {
-    $value = implode(' ', $value);
+  $return_values = array();
+  foreach ($field_values as $key => $values) {
+    foreach ($values as $column => $value) {
+      // For some reason we get an `_attributes` column which is an array.
+      if ($column !== "value") {
+        continue;
+      }
+
+      // ALL THE VALUES!
+      if (is_array($value)) {
+        $value = implode(' ', $value);
+      }
+
+      $return_values[] = $value;
+    }
   }
-  return implode(' ', $field_values);
+
+  return implode(' ', $return_values);
 }
 
 /**

--- a/modules/ui_patterns_variants/ui_patterns_variants.module
+++ b/modules/ui_patterns_variants/ui_patterns_variants.module
@@ -200,10 +200,10 @@ function ui_patterns_variants_preprocess_panelizer_view_mode(&$variables) {
 
   // Apply pattern variants to items rendered in panels when available.
   $config = $variables['element']['#panels_display']->getConfiguration();
-  if (!empty($config['layout_settings']['pattern']['variants'])) {
+  if (empty($config['layout_settings']['pattern']['variants'])) {
     return;
   }
-
+  
   // Loop through all of the variant settings and apply them to the template.
   $variant_settings = [];
   foreach ($config['layout_settings']['pattern']['variants'] as $key => $variant) {

--- a/modules/ui_patterns_variants/ui_patterns_variants.module
+++ b/modules/ui_patterns_variants/ui_patterns_variants.module
@@ -203,7 +203,7 @@ function ui_patterns_variants_preprocess_panelizer_view_mode(&$variables) {
   if (empty($config['layout_settings']['pattern']['variants'])) {
     return;
   }
-  
+
   // Loop through all of the variant settings and apply them to the template.
   $variant_settings = [];
   foreach ($config['layout_settings']['pattern']['variants'] as $key => $variant) {
@@ -487,10 +487,20 @@ function _ui_patterns_variants_get_form_elements(array $variants, array $default
       continue;
     }
 
+    // Validation label.
+    if (!isset($variant['label'])) {
+      drupal_set_message(t("%variant_key is missing label", array("%variant_key" => $key)), 'error', FALSE);
+    }
+
+    // Validation description.
+    if (!isset($variant['description'])) {
+      drupal_set_message(t("%variant_key is missing description", array("%variant_key" => $key)), 'error', FALSE);
+    }
+
     $pattern_settings['variants'][$key] = [
       '#type' => 'fieldset',
-      '#title' => $variant['label'],
-      '#description' => isset($variant['description']) ? $variant['description'] : '',
+      '#title' => isset($variant['label']) ? $variant['label'] : t("Missing label"),
+      '#description' => isset($variant['description']) ? $variant['description'] : t('No description.'),
     ];
 
     $available_options = [];


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Configures the variants for Stanford Postcard using the new ui_patterns_variants module.

# Needed By (Date)
- Mid sprint review (July 6th)

# Urgency
- Moderate(ish)

# Steps to Test

1. Checkout the EARTH-134 branch of https://github.com/stanford-earth/SE3_BLT
2. Run composer update to get the new version of ui_patterns
3. Checkout all of the other 3 PRs to branch EARTH-134
 - stanford_paragraph_types 
 - stanford_components 
 - ui_patterns
4. Import site config and feature config 
 - `drush cim`
 - `drush csim local`
 - `drush features-import stanford_paragraph_postcard`
5. Create a new complex page and add a Postcard Paragraph
6. Fill out the fields and play around with the variants.

# Affected Projects or Products
 - SE3_BLT
 - stanford_paragraph_types 
 - stanford_components 
 - ui_patterns

# Associated Issues and/or People
None.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)