### PR TITLE
PHP Error for missing needle.

### DIFF
--- a/modules/ui_patterns_variants/ui_patterns_variants.module
+++ b/modules/ui_patterns_variants/ui_patterns_variants.module
@@ -294,7 +294,7 @@ function _ui_patterns_variants_validate_variants($pattern, array &$variant_setti
     // Remove anything that is not one of the defined YAML options.
     $limited_options = [];
     foreach (array_keys($variant['options']) as $option) {
-      if (strpos($variant_settings[$key], "$option") !== FALSE) {
+      if (!empty($option) && strpos($variant_settings[$key], "$option") !== FALSE) {
         $limited_options[] = $option;
       }
     }


### PR DESCRIPTION
Check for an empty needle to avoid PHP errors.